### PR TITLE
frontend optimizations

### DIFF
--- a/app/assets/stylesheets/components/_article_cards.scss
+++ b/app/assets/stylesheets/components/_article_cards.scss
@@ -27,9 +27,25 @@
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    font-weight: 900;
   }
 
   .card-footer {
     flex-shrink: 0;
+  }
+}
+
+.curation-pill {
+  background: $bright-yellow;
+  border-radius: 20px !important;
+  padding: 0.5rem 1rem !important;
+
+  &:hover {
+    background-color: darken($bright-yellow, 15%) !important;
+    }
+
+  a {
+    color: $black !important;
+    text-decoration: none;
   }
 }

--- a/app/assets/stylesheets/components/_button_primary.scss
+++ b/app/assets/stylesheets/components/_button_primary.scss
@@ -2,6 +2,7 @@
   background-color: $primary !important;
   border-color: $primary !important;
   color: $white !important;
+  border-radius: 10px;
 
   &:hover {
   background-color: darken($primary, 15%) !important;

--- a/app/assets/stylesheets/components/_button_secondary.scss
+++ b/app/assets/stylesheets/components/_button_secondary.scss
@@ -2,6 +2,7 @@
   background-color: $secondary !important;
   border-color: $secondary !important;
   color: $black !important;
+  border-radius: 10px !important;
 
     &:hover {
   background-color: darken($secondary, 15%) !important;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -9,6 +9,20 @@
   z-index: 1000;
 }
 
+.navbar-lewagon.d-md-none .mobile-center-nav {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  text-align: center;
+  pointer-events: none;
+}
+
+.navbar-lewagon.d-md-none .mobile-center-nav .dropdown {
+  pointer-events: auto;
+}
+
 .navbar-lewagon .navbar-collapse {
   flex-grow: 0;
 }
@@ -16,6 +30,7 @@
 .navbar-lewagon .navbar-brand img {
   width: 56px;
   height: auto;
+  margin-top: 0.75rem;
 }
 
 .navbar-lewagon h2 a {
@@ -34,6 +49,7 @@
   border: none;
   border-radius: 0;
   background: $light-cappuccino;
+  padding-right: 0.75rem;
 }
 
 body {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
 
   def after_sign_in_path_for(resource)
+    flash.delete(:notice) # remove Devise's default successful login message
     articles_path
   end
 end

--- a/app/views/articles/_article_head.html.erb
+++ b/app/views/articles/_article_head.html.erb
@@ -1,4 +1,4 @@
-  <h1 class="mb-2"><%= article.headline %></h1>
+  <h1 class="mb-2 fw-bold"><%= article.headline %></h1>
 
   <% if article.subheadline.present? %>
     <p class="lead text-muted mb-3"><%= article.subheadline %></p>
@@ -19,9 +19,9 @@
 
     <% if article.curations.any? %>
       <% article.curations.each do |curation| %>
-        <span class="badge bg-secondary text-dark border">
-      <%=link_to curation.title, curation_path(curation), class: "text-decoration-none text-dark"%>
-      </span>
+        <span class="curation-pill p-2">
+          <%= link_to curation.title, curation_path(curation) %>
+        </span>
       <% end %>
     <% end %>
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container my-4">
-  <%= link_to "← Back to Articles", articles_path, class: "btn btn-secondary mb-3" %>
-  <%= link_to "See ChatBot conversation", conversation_path(@article.conversations.first), class: "btn btn-primary mb-3" %>
+  <%= link_to "← Back", articles_path, class: "btn btn-secondary mb-3" %>
+  <%= link_to "ChatBot", conversation_path(@article.conversations.first), class: "btn btn-primary mb-3" %>
 
   <%= render layout: "articles/article_head", locals: { article: @article } do %>
 

--- a/app/views/shared/navbar/_mobile.html.erb
+++ b/app/views/shared/navbar/_mobile.html.erb
@@ -1,8 +1,8 @@
 <nav class="navbar navbar-light navbar-lewagon d-md-none">
-  <div class="container-fluid">
+  <div class="container-fluid position-relative">
     <%= render "shared/navbar/logo" %>
 
-    <div class="flex-grow-1 text-center">
+    <div class="mobile-center-nav text-center">
       <div class="dropdown d-inline-block" data-controller="mobile-dropdown">
         <a href="#"
           class="nav-link dropdown-toggle text-dark fw-semibold text-center px-0"
@@ -18,7 +18,7 @@
       </div>
     </div>
 
-    <div class="dropdown" data-controller="mobile-dropdown">
+    <div class="dropdown me-3" data-controller="mobile-dropdown">
       <a href="#"
          class="nav-link dropdown-toggle-no-caret text-dark"
          id="mobileAccountDropdown"

--- a/app/views/shared/navbar/_nav_links.html.erb
+++ b/app/views/shared/navbar/_nav_links.html.erb
@@ -1,5 +1,5 @@
 <li><%= link_to "My Articles", root_path, class: "dropdown-item" %></li>
-<li><%= link_to "My Summary Prompts", summary_prompts_path, class: "dropdown-item" %></li>
-<li><%= link_to "My Curations", curations_path, class: "dropdown-item" %></li>
+<li><%= link_to "Curations", curations_path, class: "dropdown-item" %></li>
 <li><%= link_to "Favourites", favourites_articles_path, class: "dropdown-item" %></li>
 <li><%= link_to "Archived", archived_articles_path, class: "dropdown-item" %></li>
+<li><%= link_to "Summary Prompts", summary_prompts_path, class: "dropdown-item" %></li>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Polishes UI (mobile navbar centering, curation pills, rounded buttons, bold headlines, shorter labels) and suppresses Devise login success notice.
> 
> - **UI/Styling**
>   - **Navbar (mobile)**: Center navigation dropdown via `.mobile-center-nav`; adjust pointer-events; add `position-relative` container; add right margin to account dropdown; tweak logo top margin; add padding to `.mobile-nav-dropdown` in `app/assets/stylesheets/components/_navbar.scss` and `app/views/shared/navbar/_mobile.html.erb`.
>   - **Buttons**: Add `border-radius: 10px` to `.btn-primary` and `.btn-secondary`.
>   - **Articles**:
>     - Make `.card-title` bold and replace curation badges with `curation-pill` chips in `app/views/articles/_article_head.html.erb` with styles in `app/assets/stylesheets/components/_article_cards.scss`.
>     - Shorten action labels in `app/views/articles/show.html.erb` ("← Back", "ChatBot").
>   - **Nav links**: Reorder/rename items in `app/views/shared/navbar/_nav_links.html.erb` ("Curations", "Summary Prompts").
> - **Auth/Behavior**
>   - Remove Devise default success flash in `ApplicationController#after_sign_in_path_for`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b217ca37a7c2992e6a2baa746137d8569371b46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->